### PR TITLE
Fix for the CPCEMU disk images that are not recognized as such

### DIFF
--- a/DiscImageChef.DiscImages/CPCDSK/Constants.cs
+++ b/DiscImageChef.DiscImages/CPCDSK/Constants.cs
@@ -1,4 +1,4 @@
-﻿// /***************************************************************************
+// /***************************************************************************
 // The Disc Image Chef
 // ----------------------------------------------------------------------------
 //
@@ -35,12 +35,11 @@ namespace DiscImageChef.DiscImages
     public partial class Cpcdsk
     {
         /// <summary>
-        ///     Identifier for CPCEMU disk images, "MV - CPCEMU Disk-File"
+        ///     Identifier for CPCEMU disk images, "MV - CPC" + usually : "EMU Disk-File\r\nDisk-Info\r\n" but not required
         /// </summary>
         readonly byte[] cpcdskId =
         {
-            0x4D, 0x56, 0x20, 0x2D, 0x20, 0x43, 0x50, 0x43, 0x45, 0x4D, 0x55, 0x20, 0x44, 0x69, 0x73, 0x6B, 0x2D,
-            0x46, 0x69, 0x6C, 0x65
+            0x4D, 0x56, 0x20, 0x2D, 0x20, 0x43, 0x50, 0x43
         };
         /// <summary>
         ///     Identifier for DU54 disk images, "MV - CPC format Disk Image (DU54)"

--- a/DiscImageChef.DiscImages/CPCDSK/Identify.cs
+++ b/DiscImageChef.DiscImages/CPCDSK/Identify.cs
@@ -1,4 +1,4 @@
-﻿// /***************************************************************************
+// /***************************************************************************
 // The Disc Image Chef
 // ----------------------------------------------------------------------------
 //
@@ -54,7 +54,7 @@ namespace DiscImageChef.DiscImages
             DicConsole.DebugWriteLine("CPCDSK plugin", "header.magic = \"{0}\"",
                                       StringHandlers.CToString(header.magic));
 
-            return cpcdskId.SequenceEqual(header.magic) || edskId.SequenceEqual(header.magic) ||
+            return cpcdskId.SequenceEqual(header.magic.Take(cpcdskId.Length)) || edskId.SequenceEqual(header.magic) ||
                    du54Id.SequenceEqual(header.magic);
         }
     }

--- a/DiscImageChef.DiscImages/CPCDSK/Read.cs
+++ b/DiscImageChef.DiscImages/CPCDSK/Read.cs
@@ -1,4 +1,4 @@
-﻿// /***************************************************************************
+// /***************************************************************************
 // The Disc Image Chef
 // ----------------------------------------------------------------------------
 //
@@ -59,7 +59,7 @@ namespace DiscImageChef.DiscImages
             stream.Read(headerB, 0, 256);
             CpcDiskInfo header = Marshal.ByteArrayToStructureLittleEndian<CpcDiskInfo>(headerB);
 
-            if(!cpcdskId.SequenceEqual(header.magic) &&
+            if(!cpcdskId.SequenceEqual(header.magic.Take(cpcdskId.Length)) &&
                !edskId.SequenceEqual(header.magic)   &&
                !du54Id.SequenceEqual(header.magic))
                 return false;

--- a/DiscImageChef.DiscImages/CPCDSK/Structs.cs
+++ b/DiscImageChef.DiscImages/CPCDSK/Structs.cs
@@ -1,4 +1,4 @@
-﻿// /***************************************************************************
+// /***************************************************************************
 // The Disc Image Chef
 // ----------------------------------------------------------------------------
 //
@@ -41,7 +41,7 @@ namespace DiscImageChef.DiscImages
         struct CpcDiskInfo
         {
             /// <summary>
-            ///     Magic number, "MV - CPCEMU Disk-File" in old files, "EXTENDED CPC DSK File" in extended ones
+            ///     Magic number, "MV - CPC" in old files, "EXTENDED CPC DSK File" in extended ones
             /// </summary>
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 21)]
             public byte[] magic;

--- a/DiscImageChef.Filesystems/CPM/Definitions.cs
+++ b/DiscImageChef.Filesystems/CPM/Definitions.cs
@@ -81,7 +81,7 @@ namespace DiscImageChef.Filesystems.CPM
     /// <summary>
     ///     CP/M disk definitions
     /// </summary>
-    class CpmDefinitions
+    public class CpmDefinitions
     {
         /// <summary>
         ///     Timestamp of creation of the CP/M disk definitions list
@@ -96,7 +96,7 @@ namespace DiscImageChef.Filesystems.CPM
     /// <summary>
     ///     CP/M disk definition
     /// </summary>
-    class CpmDefinition
+    public class CpmDefinition
     {
         /// <summary>
         ///     Maps the first 16 allocation blocks for reservation, high byte
@@ -196,7 +196,7 @@ namespace DiscImageChef.Filesystems.CPM
     /// <summary>
     ///     Side descriptions
     /// </summary>
-    class Side
+    public class Side
     {
         /// <summary>
         ///     Software interleaving mask, [1,3,0,2] means CP/M LBA 0 is physical sector 1, LBA 1 = 3, so on

--- a/DiscImageChef.Filesystems/CPM/Super.cs
+++ b/DiscImageChef.Filesystems/CPM/Super.cs
@@ -367,8 +367,8 @@ namespace DiscImageChef.Filesystems.CPM
                         // allocate block 0 for a file because that's where the directory resides.
                         // There is also a field telling how many bytes are used in the last block, but its meaning is
                         // non-standard so we must ignore it.
-                        foreach(ushort blk in entry.allocations.Cast<ushort>()
-                                                   .Where(blk => !blocks.Contains(blk) && blk != 0)) blocks.Add(blk);
+                        foreach(byte blk in entry.allocations
+                                                   .Where(blk => !blocks.Contains((ushort)blk) && blk != 0)) blocks.Add((ushort)blk);
 
                         // Save the file
                         fInfo.UID = (ulong)user;

--- a/DiscImageChef.Filesystems/CPM/Super.cs
+++ b/DiscImageChef.Filesystems/CPM/Super.cs
@@ -367,8 +367,8 @@ namespace DiscImageChef.Filesystems.CPM
                         // allocate block 0 for a file because that's where the directory resides.
                         // There is also a field telling how many bytes are used in the last block, but its meaning is
                         // non-standard so we must ignore it.
-                        foreach(byte blk in entry.allocations
-                                                   .Where(blk => !blocks.Contains((ushort)blk) && blk != 0)) blocks.Add((ushort)blk);
+                        foreach(ushort blk in entry.allocations
+                                                   .Where(blk => !blocks.Contains(blk) && blk != 0)) blocks.Add(blk);
 
                         // Save the file
                         fInfo.UID = (ulong)user;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New disc image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Source for the limitation of how much magic bytes are checked in the header : 
[cpc-wiki](http://www.cpcwiki.eu/index.php/Format:DSK_disk_image_file_format
)
[original specification](http://www.cpctech.org.uk/docs/dsk.html)
Closes #279 
